### PR TITLE
Fixed install_pro.sh

### DIFF
--- a/install_pro.sh
+++ b/install_pro.sh
@@ -2288,15 +2288,15 @@ fi
     create_service_scripts
     create_service
     
-   # if whiptail --yesno "Is the fluxnode being installed on a vps?" 8 60; then   
-   #   echo -e "${ARROW} ${YELLOW}Cron service for rotate ip skipped...${NC}"
-  #  else
-      # if whiptail --yesno "Would you like to install cron service for rotate ip (required for dynamic ip)?" 8 60; then
+    if whiptail --yesno "Is the fluxnode being installed on a vps?" 8 60; then   
+      echo -e "${ARROW} ${YELLOW}Cron service for rotate ip skipped...${NC}"
+    else
+       if whiptail --yesno "Would you like to install cron service for rotate ip (required for dynamic ip)?" 8 60; then
          selfhosting
-      ## else
-         #echo -e "${ARROW} ${YELLOW}Cron service for rotate ip skipped...${NC}"
-      ### fi 
-  ##  fi
+       else
+         echo -e "${ARROW} ${YELLOW}Cron service for rotate ip skipped...${NC}"
+       fi 
+    fi
     
     install_process
     start_daemon


### PR DESCRIPTION
You need to roll back the change.
This solution is not suitable for a dedicated server where the address is already present on the interface.

OpenVZ  has a link, which results in an error.
2: venet0: <BROADCAST,POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default